### PR TITLE
Test disconnection from outdated peers on network upgrade

### DIFF
--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -15,7 +15,12 @@ mod load_tracked_client;
 /// Watches for chain tip height updates to determine the minimum support peer protocol version.
 mod minimum_peer_version;
 
-use client::{ClientRequest, ClientRequestReceiver, InProgressClientRequest, MustUseOneshotSender};
+#[cfg(not(test))]
+use client::ClientRequest;
+#[cfg(test)]
+pub(crate) use client::ClientRequest;
+
+use client::{ClientRequestReceiver, InProgressClientRequest, MustUseOneshotSender};
 
 pub use client::Client;
 pub use connection::Connection;

--- a/zebra-network/src/peer/minimum_peer_version.rs
+++ b/zebra-network/src/peer/minimum_peer_version.rs
@@ -2,6 +2,9 @@ use zebra_chain::{chain_tip::ChainTip, parameters::Network};
 
 use crate::protocol::external::types::Version;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+mod tests;
+
 /// A helper type to monitor the chain tip in order to determine the minimum peer protocol version
 /// that is currently supported.
 pub struct MinimumPeerVersion<C> {

--- a/zebra-network/src/peer/minimum_peer_version/tests.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use tokio::sync::watch;
 
-use zebra_chain::{block, chain_tip::ChainTip, transaction};
+use zebra_chain::{block, chain_tip::ChainTip, parameters::Network, transaction};
+
+use super::MinimumPeerVersion;
 
 #[cfg(test)]
 mod prop;
@@ -42,5 +44,14 @@ impl ChainTip for MockChainTip {
 
     fn best_tip_mined_transaction_ids(&self) -> Arc<[transaction::Hash]> {
         unreachable!("Method not used in `MinimumPeerVersion` tests");
+    }
+}
+
+impl MinimumPeerVersion<MockChainTip> {
+    pub fn with_mock_chain_tip(network: Network) -> (Self, watch::Sender<Option<block::Height>>) {
+        let (chain_tip, best_tip_height) = MockChainTip::new();
+        let minimum_peer_version = MinimumPeerVersion::new(chain_tip, network);
+
+        (minimum_peer_version, best_tip_height)
     }
 }

--- a/zebra-network/src/peer/minimum_peer_version/tests.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use tokio::sync::watch;
+
+use zebra_chain::{block, chain_tip::ChainTip, transaction};
+
+#[cfg(test)]
+mod prop;
+
+/// A mock [`ChainTip`] implementation that allows setting the `best_tip_height` externally.
+#[derive(Clone)]
+pub struct MockChainTip {
+    best_tip_height: watch::Receiver<Option<block::Height>>,
+}
+
+impl MockChainTip {
+    /// Create a new [`MockChainTip`].
+    ///
+    /// Returns the [`MockChainTip`] instance and the endpoint to modiy the current best tip
+    /// height.
+    ///
+    /// Initially, the best tip height is [`None`].
+    pub fn new() -> (Self, watch::Sender<Option<block::Height>>) {
+        let (sender, receiver) = watch::channel(None);
+
+        let mock_chain_tip = MockChainTip {
+            best_tip_height: receiver,
+        };
+
+        (mock_chain_tip, sender)
+    }
+}
+
+impl ChainTip for MockChainTip {
+    fn best_tip_height(&self) -> Option<block::Height> {
+        *self.best_tip_height.borrow()
+    }
+
+    fn best_tip_hash(&self) -> Option<block::Hash> {
+        unreachable!("Method not used in `MinimumPeerVersion` tests");
+    }
+
+    fn best_tip_mined_transaction_ids(&self) -> Arc<[transaction::Hash]> {
+        unreachable!("Method not used in `MinimumPeerVersion` tests");
+    }
+}

--- a/zebra-network/src/peer/minimum_peer_version/tests/prop.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests/prop.rs
@@ -1,0 +1,25 @@
+use proptest::prelude::*;
+
+use zebra_chain::{block, parameters::Network};
+
+use crate::{peer::MinimumPeerVersion, protocol::external::types::Version};
+
+proptest! {
+    /// Test if the calculated minimum peer version is correct.
+    #[test]
+    fn minimum_peer_version_is_correct(
+        network in any::<Network>(),
+        block_height in any::<Option<block::Height>>(),
+    ) {
+        let (mut minimum_peer_version, best_tip_height) =
+            MinimumPeerVersion::with_mock_chain_tip(network);
+
+        best_tip_height
+            .send(block_height)
+            .expect("receiving endpoint lives as long as `minimum_peer_version`");
+
+        let expected_minimum_version = Version::min_remote_for_height(network, block_height);
+
+        prop_assert_eq!(minimum_peer_version.current(), expected_minimum_version);
+    }
+}

--- a/zebra-network/src/peer/minimum_peer_version/tests/prop.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests/prop.rs
@@ -22,4 +22,24 @@ proptest! {
 
         prop_assert_eq!(minimum_peer_version.current(), expected_minimum_version);
     }
+
+    /// Test if the calculated minimum peer version changes with the tip height.
+    #[test]
+    fn minimum_peer_version_is_updated_with_chain_tip(
+        network in any::<Network>(),
+        block_heights in any::<Vec<Option<block::Height>>>(),
+    ) {
+        let (mut minimum_peer_version, best_tip_height) =
+            MinimumPeerVersion::with_mock_chain_tip(network);
+
+        for block_height in block_heights {
+            best_tip_height
+                .send(block_height)
+                .expect("receiving endpoint lives as long as `minimum_peer_version`");
+
+            let expected_minimum_version = Version::min_remote_for_height(network, block_height);
+
+            prop_assert_eq!(minimum_peer_version.current(), expected_minimum_version);
+        }
+    }
 }

--- a/zebra-network/src/peer/minimum_peer_version/tests/prop.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests/prop.rs
@@ -42,4 +42,41 @@ proptest! {
             prop_assert_eq!(minimum_peer_version.current(), expected_minimum_version);
         }
     }
+
+    /// Test if the minimum peer version changes are correctly tracked.
+    #[test]
+    fn minimum_peer_version_reports_changes_correctly(
+        network in any::<Network>(),
+        block_height_updates in any::<Vec<Option<Option<block::Height>>>>(),
+    ) {
+        let (mut minimum_peer_version, best_tip_height) =
+            MinimumPeerVersion::with_mock_chain_tip(network);
+
+        let mut current_minimum_version = Version::min_remote_for_height(network, None);
+        let mut expected_minimum_version = Some(current_minimum_version);
+
+        prop_assert_eq!(minimum_peer_version.changed(), expected_minimum_version);
+
+        for update in block_height_updates {
+            if let Some(new_block_height) = update {
+                best_tip_height
+                    .send(new_block_height)
+                    .expect("receiving endpoint lives as long as `minimum_peer_version`");
+
+                let new_minimum_version = Version::min_remote_for_height(network, new_block_height);
+
+                expected_minimum_version = if new_minimum_version != current_minimum_version {
+                    Some(new_minimum_version)
+                } else {
+                    None
+                };
+
+                current_minimum_version = new_minimum_version;
+            } else {
+                expected_minimum_version = None;
+            }
+
+            prop_assert_eq!(minimum_peer_version.changed(), expected_minimum_version);
+        }
+    }
 }

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -87,6 +87,9 @@ use crate::{
     AddressBook, BoxError, Config,
 };
 
+#[cfg(test)]
+mod tests;
+
 /// A signal sent by the [`PeerSet`] when it has no ready peers, and gets a request from Zebra.
 ///
 /// In response to this signal, the crawler tries to open more peer connections.

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -1,0 +1,50 @@
+use futures::channel::{mpsc, oneshot};
+
+use crate::{
+    peer::{Client, ClientRequest, ErrorSlot, LoadTrackedClient},
+    protocol::external::types::Version,
+};
+
+/// A handle to a mocked [`Client`] instance.
+struct MockedClientHandle {
+    _request_receiver: mpsc::Receiver<ClientRequest>,
+    shutdown_receiver: oneshot::Receiver<()>,
+    version: Version,
+}
+
+impl MockedClientHandle {
+    /// Create a new mocked [`Client`] instance, returning it together with a handle to track it.
+    pub fn new(version: Version) -> (Self, LoadTrackedClient) {
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let (request_sender, _request_receiver) = mpsc::channel(1);
+
+        let client = Client {
+            shutdown_tx: Some(shutdown_sender),
+            server_tx: request_sender,
+            error_slot: ErrorSlot::default(),
+            version,
+        };
+
+        let handle = MockedClientHandle {
+            _request_receiver,
+            shutdown_receiver,
+            version,
+        };
+
+        (handle, client.into())
+    }
+
+    /// Gets the peer protocol version associated to the [`Client`].
+    pub fn version(&self) -> Version {
+        self.version
+    }
+
+    /// Checks if the [`Client`] instance has not been dropped, which would have disconnected from
+    /// the peer.
+    pub fn is_connected(&mut self) -> bool {
+        match self.shutdown_receiver.try_recv() {
+            Ok(None) => true,
+            Ok(Some(())) | Err(oneshot::Canceled) => false,
+        }
+    }
+}

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -1,9 +1,22 @@
-use futures::channel::{mpsc, oneshot};
+use std::net::SocketAddr;
+
+use futures::{
+    channel::{mpsc, oneshot},
+    stream, Stream, StreamExt,
+};
+use proptest::{collection::vec, prelude::any};
+use proptest_derive::Arbitrary;
+use tower::{discover::Change, BoxError};
 
 use crate::{
     peer::{Client, ClientRequest, ErrorSlot, LoadTrackedClient},
     protocol::external::types::Version,
 };
+
+/// The maximum number of arbitrary peers to generate in [`PeerVersions`].
+///
+/// This affects the maximum number of peer connections added to the [`PeerSet`] during the tests.
+const MAX_PEERS: usize = 20;
 
 /// A handle to a mocked [`Client`] instance.
 struct MockedClientHandle {
@@ -46,5 +59,65 @@ impl MockedClientHandle {
             Ok(None) => true,
             Ok(Some(())) | Err(oneshot::Canceled) => false,
         }
+    }
+}
+
+/// A helper type to generate arbitrary peer versions which can then become mock peer services.
+#[derive(Arbitrary, Debug)]
+struct PeerVersions {
+    #[proptest(strategy = "vec(any::<Version>(), 1..MAX_PEERS)")]
+    peer_versions: Vec<Version>,
+}
+
+impl PeerVersions {
+    /// Convert the arbitrary peer versions into mock peer services.
+    ///
+    /// Each peer versions results in a mock peer service, which is returned as a tuple. The first
+    /// element is the [`LeadTrackedClient`], which is the actual service for the peer connection.
+    /// The second element is a [`MockedClientHandle`], which contains the open endpoints of the
+    /// mock channels used by the peer service.
+    pub fn mock_peers(&self) -> (Vec<LoadTrackedClient>, Vec<MockedClientHandle>) {
+        let mut clients = Vec::with_capacity(self.peer_versions.len());
+        let mut handles = Vec::with_capacity(self.peer_versions.len());
+
+        for peer_version in &self.peer_versions {
+            let (handle, client) = MockedClientHandle::new(*peer_version);
+
+            clients.push(client);
+            handles.push(handle);
+        }
+
+        (clients, handles)
+    }
+
+    /// Convert the arbitrary peer versions into mock peer services available through a
+    /// [`Discover`] compatible stream.
+    ///
+    /// A tuple is returned, where the first item is a stream with the mock peers available through
+    /// a [`Discover`] interface, and the second is a list of handles to the mocked services.
+    ///
+    /// The returned stream never finishes, so it is ready to be passed to the [`PeerSet`]
+    /// constructor.
+    ///
+    /// See [`Self::mock_peers`] for details on how the peers are mocked and on what the handles
+    /// contain.
+    pub fn mock_peer_discovery(
+        &self,
+    ) -> (
+        impl Stream<Item = Result<Change<SocketAddr, LoadTrackedClient>, BoxError>>,
+        Vec<MockedClientHandle>,
+    ) {
+        let (clients, handles) = self.mock_peers();
+        let fake_ports = 1_u16..;
+
+        let discovered_peers_iterator = fake_ports.zip(clients).map(|(port, client)| {
+            let peer_address = SocketAddr::new([127, 0, 0, 1].into(), port);
+
+            Ok(Change::Insert(peer_address, client))
+        });
+
+        let discovered_peers = stream::iter(discovered_peers_iterator).chain(stream::pending());
+
+        (discovered_peers, handles)
     }
 }

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -23,6 +23,9 @@ use crate::{
     AddressBook, Config,
 };
 
+#[cfg(test)]
+mod prop;
+
 /// The maximum number of arbitrary peers to generate in [`PeerVersions`].
 ///
 /// This affects the maximum number of peer connections added to the [`PeerSet`] during the tests.

--- a/zebra-network/src/peer_set/set/tests/prop.rs
+++ b/zebra-network/src/peer_set/set/tests/prop.rs
@@ -1,0 +1,92 @@
+use std::net::SocketAddr;
+
+use futures::FutureExt;
+use proptest::prelude::*;
+use tower::{discover::Discover, BoxError, ServiceExt};
+
+use zebra_chain::{block, chain_tip::ChainTip, parameters::Network};
+
+use super::{MockedClientHandle, PeerSetBuilder, PeerVersions};
+use crate::{
+    peer::{LoadTrackedClient, MinimumPeerVersion},
+    peer_set::PeerSet,
+    protocol::external::types::Version,
+};
+
+proptest! {
+    /// Check if discovered outdated peers are immediately dropped by the [`PeerSet`].
+    #[test]
+    fn only_non_outdated_peers_are_accepted(
+        network in any::<Network>(),
+        block_height in any::<block::Height>(),
+        peer_versions in any::<PeerVersions>(),
+    ) {
+        let runtime = zebra_test::init_async();
+
+        let (discovered_peers, mut handles) = peer_versions.mock_peer_discovery();
+        let (mut minimum_peer_version, best_tip_height) =
+            MinimumPeerVersion::with_mock_chain_tip(network);
+
+        best_tip_height
+            .send(Some(block_height))
+            .expect("receiving endpoint lives as long as `minimum_peer_version`");
+
+        let current_minimum_version = minimum_peer_version.current();
+
+        runtime.block_on(async move {
+            let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+                .with_discover(discovered_peers)
+                .with_minimum_peer_version(minimum_peer_version)
+                .build();
+
+            check_if_only_up_to_date_peers_are_live(
+                &mut peer_set,
+                &mut handles,
+                current_minimum_version,
+            )?;
+
+            Ok::<_, TestCaseError>(())
+        })?;
+    }
+}
+
+/// Check if only peers with up-to-date protocol versions are live.
+///
+/// This will poll the `peer_set` to allow it to drop outdated peers, and then check the peer
+/// `handles` to assert that only up-to-date peers are kept by the `peer_set`.
+fn check_if_only_up_to_date_peers_are_live<D, C>(
+    peer_set: &mut PeerSet<D, C>,
+    handles: &mut Vec<MockedClientHandle>,
+    minimum_version: Version,
+) -> Result<(), TestCaseError>
+where
+    D: Discover<Key = SocketAddr, Service = LoadTrackedClient> + Unpin,
+    D::Error: Into<BoxError>,
+    C: ChainTip,
+{
+    // Force `poll_discover` to be called to process all discovered peers.
+    let poll_result = peer_set.ready().now_or_never();
+    let all_peers_are_outdated = handles
+        .iter()
+        .all(|handle| handle.version() < minimum_version);
+
+    if all_peers_are_outdated {
+        prop_assert!(matches!(poll_result, None));
+    } else {
+        prop_assert!(matches!(poll_result, Some(Ok(_))));
+    }
+
+    for handle in handles {
+        let is_outdated = handle.version() < minimum_version;
+        let is_connected = handle.is_connected();
+
+        prop_assert!(
+            is_connected != is_outdated,
+            "is_connected: {}, is_outdated: {}",
+            is_connected,
+            is_outdated,
+        );
+    }
+
+    Ok(())
+}

--- a/zebra-network/src/peer_set/set/tests/prop.rs
+++ b/zebra-network/src/peer_set/set/tests/prop.rs
@@ -6,7 +6,9 @@ use tower::{discover::Discover, BoxError, ServiceExt};
 
 use zebra_chain::{block, chain_tip::ChainTip, parameters::Network};
 
-use super::{MockedClientHandle, PeerSetBuilder, PeerVersions};
+use super::{
+    BlockHeightPairAcrossNetworkUpgrades, MockedClientHandle, PeerSetBuilder, PeerVersions,
+};
 use crate::{
     peer::{LoadTrackedClient, MinimumPeerVersion},
     peer_set::PeerSet,
@@ -43,6 +45,47 @@ proptest! {
                 &mut peer_set,
                 &mut handles,
                 current_minimum_version,
+            )?;
+
+            Ok::<_, TestCaseError>(())
+        })?;
+    }
+
+    /// Check if peers that become outdated after a network upgrade are dropped by the [`PeerSet`].
+    #[test]
+    fn outdated_peers_are_dropped_on_network_upgrade(
+        block_heights in any::<BlockHeightPairAcrossNetworkUpgrades>(),
+        peer_versions in any::<PeerVersions>(),
+    ) {
+        let runtime = zebra_test::init_async();
+
+        let (discovered_peers, mut handles) = peer_versions.mock_peer_discovery();
+        let (mut minimum_peer_version, best_tip_height) =
+            MinimumPeerVersion::with_mock_chain_tip(block_heights.network);
+
+        best_tip_height
+            .send(Some(dbg!(block_heights.before_upgrade)))
+            .expect("receiving endpoint lives as long as `minimum_peer_version`");
+
+        runtime.block_on(async move {
+            let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+                .with_discover(discovered_peers)
+                .with_minimum_peer_version(minimum_peer_version.clone())
+                .build();
+
+            check_if_only_up_to_date_peers_are_live(
+                &mut peer_set,
+                &mut handles,
+                dbg!(minimum_peer_version.current()),
+            )?;
+
+            best_tip_height.send(Some(dbg!(block_heights.after_upgrade)))
+            .expect("receiving endpoint lives as long as `minimum_peer_version`");
+
+            check_if_only_up_to_date_peers_are_live(
+                &mut peer_set,
+                &mut handles,
+                dbg!(minimum_peer_version.current()),
             )?;
 
             Ok::<_, TestCaseError>(())

--- a/zebra-network/src/protocol/external/arbitrary.rs
+++ b/zebra-network/src/protocol/external/arbitrary.rs
@@ -9,7 +9,7 @@ use zebra_chain::{block, transaction};
 
 use super::{
     addr::{canonical_socket_addr, ipv6_mapped_socket_addr},
-    types::PeerServices,
+    types::{PeerServices, Version},
     InventoryHash, Message,
 };
 
@@ -110,6 +110,18 @@ impl Message {
             .prop_map(Message::GetData)
             .boxed()
     }
+}
+
+impl Arbitrary for Version {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        prop_oneof![170_002_u32..=170_015, 0_u32..]
+            .prop_map(Version)
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
 }
 
 /// Returns a random canonical Zebra `SocketAddr`.

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -38,7 +38,6 @@ impl From<Network> for Magic {
 
 /// A protocol version number.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct Version(pub u32);
 
 impl fmt::Display for Version {


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
Zebra should disconnect from outdated peers during a network upgrade. This was implemented in https://github.com/ZcashFoundation/zebra/pull/3108, and this PR contains some property tests for the implementation.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
